### PR TITLE
fix: replace mock data with honest placeholders

### DIFF
--- a/src/components/home/FeaturedVideos.tsx
+++ b/src/components/home/FeaturedVideos.tsx
@@ -87,7 +87,6 @@ const FeaturedVideos = () => {
               creator={video.userId}
               creatorName={userMap[video.userId]}
               thumbnail={video.thumbnailUrl || PLACEHOLDER_THUMB}
-              duration=""
               views={video.views}
               rating={video.averageRating ?? 0}
               tags={EMPTY_TAGS}

--- a/src/components/home/StatsSection.tsx
+++ b/src/components/home/StatsSection.tsx
@@ -4,27 +4,27 @@ import { Eye, User, Star, Clock } from 'lucide-react';
 const stats = [
   {
     icon: Eye,
-    value: '2.5M+',
+    value: '—',
     label: 'Total Views',
-    description: 'Videos watched by our community'
+    description: 'Coming soon'
   },
   {
     icon: User,
-    value: '50K+',
+    value: '—',
     label: 'Active Creators',
-    description: 'Contributing quality content'
+    description: 'Coming soon'
   },
   {
     icon: Star,
-    value: '4.8',
+    value: '—',
     label: 'Average Rating',
-    description: 'Quality content you can trust'
+    description: 'Coming soon'
   },
   {
     icon: Clock,
-    value: '100K+',
+    value: '—',
     label: 'Hours Streamed',
-    description: 'Of educational content'
+    description: 'Coming soon'
   }
 ];
 
@@ -37,7 +37,7 @@ const StatsSection = () => {
             Platform Statistics
           </h2>
           <p className="font-noto text-lg text-gray-600 max-w-2xl mx-auto">
-            See how our community is growing and engaging with content
+            Platform statistics coming soon
           </p>
         </div>
 

--- a/src/components/video/RelatedVideos.tsx
+++ b/src/components/video/RelatedVideos.tsx
@@ -31,7 +31,6 @@ const RelatedVideos = ({ videoId, limit = 5 }: RelatedVideosProps) => {
           title={item.title}
           creator=""
           thumbnail={item.thumbnailUrl ?? ''}
-          duration=""
           views={item.views ?? 0}
           rating={item.averageRating ?? 0}
           tags={EMPTY_TAGS}

--- a/src/components/video/VideoCard.tsx
+++ b/src/components/video/VideoCard.tsx
@@ -11,7 +11,7 @@ interface VideoCardProps {
   title: string;
   creator: string;
   thumbnail: string;
-  duration: string;
+  duration?: string;
   views?: number | null;
   rating?: number | null;
   tags: string[];
@@ -88,10 +88,12 @@ const VideoCard = memo(({
               <div className="w-12 h-12 border-4 border-primary/20 border-t-primary rounded-full animate-spin"></div>
             </div>
           )}
-          <div className="absolute bottom-2 right-2 bg-black/80 text-white text-xs px-2 py-1 rounded font-noto">
-            <Clock className="w-3 h-3 inline mr-1" />
-            {duration}
-          </div>
+          {duration && (
+            <div className="absolute bottom-2 right-2 bg-black/80 text-white text-xs px-2 py-1 rounded font-noto">
+              <Clock className="w-3 h-3 inline mr-1" />
+              {duration}
+            </div>
+          )}
         </div>
       </Link>
       

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -84,7 +84,7 @@ const SearchResults = () => {
                 creator={video.userId}
                 creatorName={userMap[video.userId]}
                 thumbnail={video.thumbnailUrl || '/placeholder.svg'}
-                duration="5:32"
+                duration="--:--"
                 views={video.viewCount}
                 rating={video.averageRating}
                 tags={EMPTY_TAGS}

--- a/src/pages/Trending.tsx
+++ b/src/pages/Trending.tsx
@@ -93,7 +93,7 @@ const Trending = () => {
                       creator={video.userId}
                       creatorName={userMap[video.userId]}
                       thumbnail={video.thumbnailUrl}
-                      duration="0:00"
+                      duration="--:--"
                       views={video.viewCount}
                       rating={video.averageRating}
                       tags={EMPTY_TAGS}


### PR DESCRIPTION
## Summary
- **Issue #29**: Replace hardcoded StatsSection statistics (2.5M+, 50K+, 4.8, 100K+) with em-dash ("—") placeholders and "Coming soon" descriptions
- **Issue #33**: Make `duration` prop optional in VideoCard, replace fake durations ("5:32", "0:00") with "--:--", and hide duration badge entirely where empty strings were passed
- Closes #40, refs #29, refs #33

## Files Changed (6)
1. `src/components/home/StatsSection.tsx` — fake stats → "—" / "Coming soon"
2. `src/components/video/VideoCard.tsx` — `duration` optional, badge conditionally rendered
3. `src/pages/SearchResults.tsx` — `"5:32"` → `"--:--"`
4. `src/pages/Trending.tsx` — `"0:00"` → `"--:--"`
5. `src/components/video/RelatedVideos.tsx` — removed empty `duration=""` prop
6. `src/components/home/FeaturedVideos.tsx` — removed empty `duration=""` prop

## Test plan
- [ ] Home page StatsSection shows "—" values with "Coming soon" descriptions
- [ ] Search results show "--:--" duration badges
- [ ] Trending page shows "--:--" duration badges
- [ ] FeaturedVideos hide duration badge entirely (no empty badge rendered)
- [ ] RelatedVideos hide duration badge entirely
- [ ] `npm run build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)